### PR TITLE
Drop Julia 0.6 and support 0.7 and 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,7 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+julia:
+  - 0.7
+  - 1.0
+  - nightly
 notifications:
   email: false
-env:
-  matrix: 
-    - JULIAVERSION="juliareleases" 
-    - JULIAVERSION="julianightlies" 
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-script:
-  - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("Psychro"))`); Pkg.pin("Psychro"); Pkg.resolve()'
-  - julia -e 'using Psychro; @assert isdefined(:Psychro); @assert typeof(Psychro) === Module'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7
 Unitful

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,20 @@
+
+
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -24,24 +28,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"Psychro\"); Pkg.build(\"Psychro\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"Psychro\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/psychrounits.jl
+++ b/src/psychrounits.jl
@@ -4,17 +4,17 @@ Implement the functions using the Unitful package to check units
 
 using Unitful
 
-const uT = u"K"
-const uP = u"Pa"
-const uV = u"m^3/kg"
-const umV = u"m^3/mol"
-const uD = u"kg/m^3"
-const umD = u"mol/m^3"
-const perc = u"cm/m"
-const uH = u"J/kg"
-const umH = u"J/mol"
-const uS = u"J/kg/K"
-const umS = u"J/mol/K"
+const uT = Unitful.K
+const uP = Unitful.Pa
+const uV = Unitful.m^3/Unitful.kg
+const umV = Unitful.m^3/Unitful.mol
+const uD = Unitful.kg/Unitful.m^3
+const umD = Unitful.mol/Unitful.m^3
+const perc = Unitful.cm/Unitful.m
+const uH = Unitful.J/Unitful.kg
+const umH = Unitful.J/Unitful.mol
+const uS = Unitful.J/Unitful.kg/Unitful.K
+const umS = Unitful.J/Unitful.mol/Unitful.K
 
 
 dimless{T,U} = Quantity{T, Unitful.Dimensions{()}, U}
@@ -25,7 +25,7 @@ val(u, x::Quantity) = uconvert(u, x).val
 val(u::Unitful.FreeUnits{(), Unitful.Dimensions{()}}, x) = uconvert(u, x)
 
 function volume(::Type{DryAir}, Tk::Quantity, P::Quantity, u=uV)
-    uconvert(u, volume(DryAir, val(uT, Tk), val(u"Pa", P))*uV)
+    uconvert(u, volume(DryAir, val(uT, Tk), val(uP, P))*uV)
 end
 
 function volumem(::Type{DryAir}, Tk::Quantity, P::Quantity, u=umV)
@@ -105,11 +105,11 @@ function molarfrac(Tk::Quantity, ::Type{RelHum}, rel, P::Quantity)
 end
 
 function molarfrac(Tk::Quantity, ::Type{DewPoint}, D::Quantity, P::Quantity)
-    molarfrac(Tk, DewPoint, uconvert(u"K", D).val, val(uP, P))
+    molarfrac(Tk, DewPoint, uconvert(uT, D).val, val(uP, P))
 end
 
 function molarfrac(Tk::Quantity, ::Type{WetBulb}, B::Quantity, P::Quantity)
-    molarfrac(val(uT, Tk), WetBulb, uconvert(u"K", B).val, val(uP, P))
+    molarfrac(val(uT, Tk), WetBulb, uconvert(uT, B).val, val(uP, P))
 end
 
 
@@ -177,7 +177,7 @@ function dewpoint(::Type{MoistAir}, Tk::Quantity,
                   ::Type{T}, y, P::Quantity, u=u"°C") where {T<:PsychroProperty}
 
     xv = molarfrac(Tk, T, y, P)
-    uconvert(u"°C", dewpoint(MoistAir, val(uT, Tk), MolarFrac, xv, val(uP, P))*uT)
+    uconvert(Unitful.°C, dewpoint(MoistAir, val(uT, Tk), MolarFrac, xv, val(uP, P))*uT)
 end
 
 
@@ -190,7 +190,7 @@ end
 
 
 function wetbulb(::Type{MoistAir}, Tk::Quantity,
-                 ::Type{T}, y, P::Quantity, u=u"°C") where {T<:PsychroProperty}
+                 ::Type{T}, y, P::Quantity, u=Unitful.°C) where {T<:PsychroProperty}
 
     xv = molarfrac(Tk, T, y, P)
     uconvert(u"°C", wetbulb(MoistAir, val(uT, Tk), MolarFrac, xv, val(uP, P))*uT)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test
-using .Psychro
+using Psychro
 
 include("test_utilities.jl")
 include("test_hyland83a.jl")

--- a/test/test_user.jl
+++ b/test/test_user.jl
@@ -115,8 +115,8 @@ end
 
 # Testing Table 20 from reference [5].
 
-Tk = vcat(5*ones(4), 25*ones(4), 50*ones(4)) + 273.15
-Tbu = [5.0, 2.0, -1.0, -3.0, 25.0, 20.0, 15.0, 10.0, 25.0, 22.0, 20.0, 19.0] + 273.15
+Tk = vcat(5*ones(4), 25*ones(4), 50*ones(4)) .+ 273.15
+Tbu = [5.0, 2.0, -1.0, -3.0, 25.0, 20.0, 15.0, 10.0, 25.0, 22.0, 20.0, 19.0] .+ 273.15
 Td = [5.0, -2.16, -11.92, -37.23, 25.0, 17.60, 7.73, -10.42, 13.47, 4.16, -5.48, -14.12]
 w = [5.42, 3.16, 1.35, 0.11, 20.17, 12.66, 6.56, 1.55, 9.67, 5.11, 2.39, 1.11]*1e-3
 rel = [100.0, 58.6, 25.1, 2.0, 100, 63.5, 33.2, 7.9, 12.5, 6.7, 3.1, 1.5]
@@ -125,7 +125,7 @@ h = [18.64, 12.97, 8.42, 5.30, 76.50, 57.38, 41.85, 29.09, 75.40, 63.58, 56.51, 
 s = [0.0697, 0.0490, 0.0319, 0.0195, 0.2698, 0.2048, 0.1506, 0.1039, 0.2610, 0.2192, 0.1934, 0.1808]
 
 P = 101325.0
-Td1 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P)-273.15
+Td1 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P) .- 273.15
 w1 =  Psychro.humrat.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P)
 rel1 =  Psychro.relhum.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P) * 100
 vol1 =  Psychro.volume.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P)
@@ -139,14 +139,14 @@ s1 =  Psychro.entropy.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P)/1000
 @test maximum(abs, h1-h) ≈ 0.0 atol=0.01
 @test maximum(abs, s1-s) ≈ 0.0 atol=0.0001
 
-Tbu1 = Psychro.wetbulb.(Psychro.MoistAir, Tk, Psychro.DewPoint, Td1+273.15, P)
+Tbu1 = Psychro.wetbulb.(Psychro.MoistAir, Tk, Psychro.DewPoint, Td1 .+ 273.15, P)
 @test maximum(abs, Tbu1-Tbu) ≈ 0.0 atol=1e-4
 Tbu2 = Psychro.wetbulb.(Psychro.MoistAir, Tk, Psychro.RelHum, rel1/100, P)
 @test maximum(abs, Tbu2-Tbu) ≈ 0.0 atol=1e-4
 Tbu3 = Psychro.wetbulb.(Psychro.MoistAir, Tk, Psychro.HumRat, w1/100, P)
 @test maximum(abs, Tbu2-Tbu) ≈ 0.0 atol=1e-4
 
-Td2 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.HumRat, w1, P)-273.15
+Td2 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.HumRat, w1, P) .- 273.15
 @test maximum(abs, Td2-Td1) ≈ 0.0 atol=1e-4
-Td3 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.RelHum, rel1/100, P)-273.15
+Td3 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.RelHum, rel1/100, P) .- 273.15
 @test maximum(abs, Td3-Td1) ≈ 0.0 atol=1e-4


### PR DESCRIPTION
I had to remove the usages of the `u""` macro due to https://github.com/ajkeller34/Unitful.jl/issues/133 . Otherwise this is pretty straightforward and should get the tests passing on v0.7 and v1.0. 